### PR TITLE
remove address0 from _callTokensReceived

### DIFF
--- a/src/ARC1-Core.lua
+++ b/src/ARC1-Core.lua
@@ -140,9 +140,7 @@ abi.register_view(name, symbol, decimals, totalSupply, balanceOf)
 -- @param   ...     addtional data, MUST be sent unaltered in call to 'tokensReceived' on 'to'
 
 local function _callTokensReceived(from, to, amount, ...)
-
-  -- if to ~= system.getContractID() and system.isContract(to) then
-  if to ~= address0 and system.isContract(to) then
+  if system.isContract(to) then
     contract.call(to, "tokensReceived", system.getSender(), from, amount, ...)
   end
 end


### PR DESCRIPTION
`address0` is never a contract, so this check is not required because `system.isContract()` will return `false`