### PR TITLE
block transfers of `0` amount

### DIFF
--- a/src/ARC1-Core.lua
+++ b/src/ARC1-Core.lua
@@ -293,10 +293,11 @@ local function _burn(from, amount)
 
   assert(amount > bignum.number(0), "ARC1: invalid amount")
 
-  assert(_balances[from] and _balances[from] >= amount, "ARC1: not enough balance")
+  local balance = _balances[from] or bignum.number(0)
+  assert(balance >= amount, "ARC1: not enough balance")
 
+  _balances[from] = balance - amount
   _totalSupply:set(_totalSupply:get() - amount)
-  _balances[from] = _balances[from] - amount
 end
 
 

--- a/src/ARC1-Core.lua
+++ b/src/ARC1-Core.lua
@@ -256,9 +256,10 @@ local function _transfer(from, to, amount, ...)
   -- block transfers of `0` amount
   assert(amount > bignum.number(0), "ARC1: invalid amount")
 
-  assert(_balances[from] and _balances[from] >= amount, "ARC1: not enough balance")
+  local balance = _balances[from] or bignum.number(0)
+  assert(balance >= amount, "ARC1: not enough balance")
 
-  _balances[from] = _balances[from] - amount
+  _balances[from] = balance - amount
   _balances[to] = (_balances[to] or bignum.number(0)) + amount
 
   return _callTokensReceived(from, to, amount, ...)

--- a/src/ARC1-Core.lua
+++ b/src/ARC1-Core.lua
@@ -291,6 +291,8 @@ local function _burn(from, amount)
   assert(not _paused:get(), "ARC1: paused contract")
   assert(not _blacklist[from], "ARC1: sender is on blacklist")
 
+  assert(amount > bignum.number(0), "ARC1: invalid amount")
+
   assert(_balances[from] and _balances[from] >= amount, "ARC1: not enough balance")
 
   _totalSupply:set(_totalSupply:get() - amount)

--- a/src/ARC1-Core.lua
+++ b/src/ARC1-Core.lua
@@ -253,6 +253,9 @@ local function _transfer(from, to, amount, ...)
   assert(not _blacklist[from], "ARC1: sender is on blacklist")
   assert(not _blacklist[to], "ARC1: recipient is on blacklist")
 
+  -- block transfers of `0` amount
+  assert(amount > bignum.number(0), "ARC1: invalid amount")
+
   assert(_balances[from] and _balances[from] >= amount, "ARC1: not enough balance")
 
   _balances[from] = _balances[from] - amount


### PR DESCRIPTION
Transfers of `0` amount are used to spam user accounts.
This change remove support for them